### PR TITLE
Add default argument for Pry#initialize extension

### DIFF
--- a/lib/break/pry/extensions.rb
+++ b/lib/break/pry/extensions.rb
@@ -4,7 +4,7 @@ module Break::Pry
   module PryExtensions
     attr_accessor :__break_session__
 
-    def initialize(options)
+    def initialize(options = {})
       super(options)
 
       @__break_session__ = options[:__break_session__]


### PR DESCRIPTION
Hi @gsamokovarov — really happy to be using break over byebug since they don't seem super eager in making it fully compatible with Zeitwerk.

I like to use the Pry command `ls`, but I noticed it wasn't working after adding break and I think I've found out why. I am not remotely knowledgeable with Pry's inner workings, so there may be a reason for the extension not already doing this, but my cursory smoke tests seem to show it's ok to add.

Pry's initialize has a default value for its options parameter. Without it, I
can't run, say:

ls Object

because that runs pry/helpers/table.rb, line 37, which calls Pry.new with no
arguments (at least in pry 0.13.1).